### PR TITLE
Fix.

### DIFF
--- a/bridge-connector/client.py
+++ b/bridge-connector/client.py
@@ -133,7 +133,7 @@ class Client:
             try:
                 if self.auth_token:
                     uri = f"wss://{self.FLAGS.host}:{self.FLAGS.port}/events/v1?authToken={self.auth_token}"
-                    async with connect(uri) as ws:
+                    async with connect(uri, ping_timeout=None) as ws:
                         await self.subscribe(ws)
                         await self.recv_msg(ws)
                 else:


### PR DESCRIPTION
Just add `ping_timeout=None` so that WebSocket connection is not dropped due to no pong response. 
Note: it may be that there's actually some problem with the server - we shall see when some potential events might start popping up (say, on Monday).