### PR TITLE
Enable Kafka access both from host and other Docker containers.

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -48,14 +48,14 @@ services:
       - '9042:9042'
     volumes:
       - 'cassandra_data:/bitnami'
-    restart: always
+    restart: on-failure
     networks:
       - preprocessing
       - backend
 
   cassandra-load-keyspace:
     image: 'docker.io/bitnami/cassandra:3-debian-10'
-    restart: always
+    restart: on-failure
     depends_on:
       - cassandra
     volumes:
@@ -67,7 +67,7 @@ services:
 
   zookeeper:
     image: wurstmeister/zookeeper
-    restart: always
+    restart: on-failure
     ports:
       - "2181:2181"
     networks:
@@ -76,18 +76,16 @@ services:
 
   kafka:
     image: wurstmeister/kafka 
-    restart: always
+    restart: on-failure
     ports:
       - "9092:9092"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER://kafka:29092,LISTENER_HOST://localhost:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER:PLAINTEXT,LISTENER_HOST:PLAINTEXT
-      KAFKA_LISTENERS: LISTENER_DOCKER://kafka:29092,LISTENER_HOST://kafka:9092
+      KAFKA_LISTENERS: LISTENER_DOCKER://0.0.0.0:29092,LISTENER_HOST://kafka:9092
       KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.soc
     depends_on:
       - zookeeper
     networks:
@@ -97,7 +95,7 @@ services:
   preprocessing-info:
     build:
       context: ./logs-preprocessing/app
-    restart: always
+    restart: on-failure
     depends_on:
       - kafka
       - cassandra
@@ -112,7 +110,7 @@ services:
         UPDATE_TYPE: "roster"
         FILEPATH: "./main/resources/roster_sample.json"
         TABLE: "roster_update"
-    restart: always
+    restart: on-failure
     depends_on:
       - kafka
       - cassandra
@@ -128,7 +126,7 @@ services:
         UPDATE_TYPE: "calls"
         TABLE: "calls"
         OUTPUT_MODE: "update"
-    restart: always
+    restart: on-failure
     depends_on:
       - kafka
       - cassandra
@@ -139,7 +137,7 @@ services:
   producer:
     build:
       context: ./logs-preprocessing/kafka
-    restart: always
+    restart: on-failure
     depends_on:
       - kafka
     networks:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -86,6 +86,8 @@ services:
       KAFKA_LISTENERS: LISTENER_DOCKER://kafka:29092,LISTENER_HOST://kafka:9092
       KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.soc
     depends_on:
       - zookeeper
     networks:
@@ -98,7 +100,6 @@ services:
     restart: always
     depends_on:
       - kafka
-      - zookeeper
       - cassandra
       - cassandra-load-keyspace
     networks:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -80,10 +80,12 @@ services:
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_BROKER_ID: 1
+      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER://kafka:29092,LISTENER_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER:PLAINTEXT,LISTENER_HOST:PLAINTEXT
+      KAFKA_LISTENERS: LISTENER_DOCKER://kafka:29092,LISTENER_HOST://kafka:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.soc
     depends_on:
       - zookeeper
     networks:

--- a/logs-preprocessing/app/Dockerfile
+++ b/logs-preprocessing/app/Dockerfile
@@ -17,7 +17,7 @@ ENV KEYSPACE="test"
 ARG TABLE=call_info_update
 ENV TABLE="${TABLE}"
 
-ENV KAFKA="kafka:9092"
+ENV KAFKA="kafka:29092"
 
 ENV CASSANDRA_HOST="cassandra"
 

--- a/logs-preprocessing/kafka/Dockerfile
+++ b/logs-preprocessing/kafka/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app/
 
 ENV FILEPATH="./resources/data.json"
 
-ENV KAFKA="kafka:9092"
+ENV KAFKA="kafka:29092"
 
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
Enable Kafka access both from host and other Docker containers. 

Now Kafka can be accessed from localhost on port 9092 and from others Docker containers on address kafka:29092.