### PR TITLE
Added call start datetime to rosterUpdate and callInfoUpdate messages

### DIFF
--- a/bridge-connector/src/connector/client/client.py
+++ b/bridge-connector/src/connector/client/client.py
@@ -1,7 +1,6 @@
 import aiohttp
 import json
 import logging
-from datetime import datetime
 from collections import namedtuple
 from aiohttp import ClientConnectionError
 from websockets import connect
@@ -40,6 +39,7 @@ class Client:
         #  - we add this info to the message if necessary
         self.subscription_ind = 2
         self.subscriptions = {}         # subscription index -> Call
+        self.calls = {}                 # call name -> Call
         self.call_ids = {}              # call ID -> Call
 
     @property
@@ -86,108 +86,80 @@ class Client:
 
         msg_type = msg_dict["message"]["type"]
         if msg_type == "callListUpdate":
-            await self.call_manager.dump(msg_dict)
-            await self.on_calls_update(msg_dict)
+            await self.on_call_list_update(msg_dict)
         elif msg_type == "callInfoUpdate" or msg_type == "rosterUpdate":
             index = msg_dict["message"]["subscriptionIndex"]
             if index in self.subscriptions:
-                await self.call_manager.dump(msg_dict)
-                await self.publish(msg_dict, msg_type)
+                if msg_type == 'callInfoUpdate':
+                    await self.on_call_info_update(msg_dict)
+                else:
+                    await self.on_roster_update(msg_dict)
             else:
                 logging.warning(f'{self.TAG}: received update after "remove": {msg_dict}')
         elif "subscriptionUpdate" in msg_type:
-            await self.call_manager.dump(msg_dict)
+            pass
         else:
             logging.warning(f'{self.TAG}: unknown message type {msg_type}')
             return
 
         return msg_dict["message"]["messageId"]
 
-    async def publish(self, msg_dict: dict, msg_type: str):
-        # Add timestamp and missing info (call ID and call name) to the message
-        #  - callListUpdate - only "add" has both name and callId, others only have callId
-        #  - callInfoUpdate - only "add" has name, others have nothing
-        #  - rosterUpdate - have nothing
-        msg_dict['date'] = datetime.now().isoformat()
-
-        if msg_type == "callListUpdate":
-            updates = msg_dict["message"]["updates"]
-            if not updates:
-                logging.warning(f'{self.TAG}: "callListUpdate" message with empty "updates" list')
-                return
-
-            for update in updates:
-                call_id = update["call"]
-                if call_id not in self.call_ids:
-                    # Conference this client does not handle
-                    continue
-
-                call = self.call_ids[call_id]
-                update['name'] = call.name
-        else:
-            index = msg_dict["message"]["subscriptionIndex"]
-            call = self.subscriptions[index]
-            if msg_type == 'callInfoUpdate':
-                msg_dict["message"]["callInfo"]["call"] = call.id
-                msg_dict["message"]["callInfo"]["name"] = call.name
-            else:
-                msg_dict["call"] = call.id
-                msg_dict["name"] = call.name
-
-        await self.call_manager.publish(msg_dict)
-
-    async def on_calls_update(self, msg_dict):
-        updates = msg_dict["message"]["updates"]
-        published = False
-
+    async def on_call_list_update(self, msg: dict):
+        # Add call name to "update" and "remove" messages (they only have call ID)
+        updates = msg["message"]["updates"]
         for update in updates:
             update_type = update["updateType"]
             call_id = update["call"]
 
             if update_type == 'add':
                 call_name = update["name"]
-                await self.call_manager.on_add_call(call_name, call_id, self)
-
-                if not published and call_id in self.call_ids:
-                    await self.publish(msg_dict, 'callListUpdate')
-                    published = True
-            elif update_type == 'update':
-                await self.call_manager.on_update_call(call_id, self)
-
-                if not published and call_id in self.call_ids:
-                    await self.publish(msg_dict, 'callListUpdate')
-                    published = True
-            elif update_type == 'remove':
-                if call_id in self.call_ids:
-                    if not published:
-                        await self.publish(msg_dict, 'callListUpdate')
-                        published = True
-
-                    call = self.call_ids[call_id]
-                    s_ind = call.ci_subscription_index
-
-                    del self.subscriptions[s_ind]
-                    del self.subscriptions[s_ind + 1]
-                    del self.call_ids[call_id]
-
-                    # TODO: should we subscribe again immediately?
-                    await self.call_manager.on_remove_call(call_id, self)
-                    logging.info(f'{self.TAG}: removed call {call.name} with ID {call_id}')
+                call = Client.Call(name=call_name, id=call_id, ci_subscription_index=None)
+                self.calls[call_name] = self.call_ids[call_id] = call
             else:
-                logging.warning(f'{self.TAG}: received calls update of type {update_type}')
+                call_name = self.calls[call_id].name
+                update['name'] = call_name
 
-    async def on_connect_to(self, call_name, call_id):
+        await self.call_manager.on_call_list_update(msg, self)
+
+    async def on_call_info_update(self, msg: dict):
+        # Add call name and call ID (only "add" has name)
+        index = msg["message"]["subscriptionIndex"]
+        call = self.subscriptions[index]
+        msg["message"]["callInfo"]["call"] = call.id
+        msg["message"]["callInfo"]["name"] = call.name
+        await self.call_manager.on_call_info_update(msg, call.name)
+
+    async def on_roster_update(self, msg: dict):
+        # Add call name and call ID
+        index = msg["message"]["subscriptionIndex"]
+        call = self.subscriptions[index]
+        msg["call"] = call.id
+        msg["name"] = call.name
+        await self.call_manager.on_roster_update(msg, call.name)
+
+    async def on_connect_to(self, call_name):
         # Setup subscription indexes for call info and roster info
         s_ind = self.subscription_ind
         self.subscription_ind += 2
 
-        call = Client.Call(name=call_name, id=call_id, ci_subscription_index=s_ind)
+        call = self.calls[call_name]
+        call.ci_subscription_index = s_ind
         self.subscriptions[s_ind] = self.subscriptions[s_ind + 1] = call
-        self.call_ids[call_id] = call
 
         # Send server subscription
         await self._subscribe()
-        logging.info(f'{self.TAG}: subscribed to call {call_name} with ID {call_id}')
+        logging.info(f'{self.TAG}: subscribed to call {call.name} with ID {call.id}')
+
+    async def on_disconnect_from(self, call_name):
+        call = self.calls[call_name]
+        s_ind = call.ci_subscription_index
+
+        del self.subscriptions[s_ind]
+        del self.subscriptions[s_ind + 1]
+        del self.calls[call_name]
+        del self.call_ids[call.id]
+
+        logging.info(f'{self.TAG}: removed call {call_name} with ID {call.id}')
 
     async def _subscribe(self):
         subscriptions = [calls_subscription]

--- a/bridge-connector/src/connector/client/manager.py
+++ b/bridge-connector/src/connector/client/manager.py
@@ -7,6 +7,7 @@ import signal
 from aiokafka import AIOKafkaProducer
 from asyncio import Queue
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from functools import partial
 
 from .client import Client
@@ -14,6 +15,7 @@ from ..config import Config
 
 
 # TODO:
+#  - do we even need callId at all?
 #  - exception handling
 #    - failure to fetch token
 #    - HTTP 401 (?) error - refresh token?
@@ -45,7 +47,7 @@ class ClientManager:
         self.dump_queue = Queue()
         self.publish_queue = Queue()
 
-        if os.path.dirname(config.dumpfile):        
+        if os.path.dirname(config.dumpfile):
             os.makedirs(os.path.dirname(config.dumpfile), exist_ok=True)
 
     def start(self):
@@ -54,12 +56,12 @@ class ClientManager:
         signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT, signal.SIGQUIT)
         for s in signals:
             loop.add_signal_handler(s, lambda s=s: asyncio.create_task(self.shutdown(loop, signal=s)))
- 
+
         def async_partial(coro_fun, *args, **kwargs):
             def run():
                 return coro_fun(*args, **kwargs)
             return run
-       
+
         file_flush_task = async_partial(self.flush_to_file, self.dump_queue, self.config.dumpfile)
         kafka_publish_task = async_partial(self.push_to_kafka)
         client_tasks = [async_partial(self.run_client, host, port) for host, port in self.config.addresses]
@@ -91,7 +93,7 @@ class ClientManager:
                 # Reset so that backoff doesn't stay large all the time
                 if (backoff_s := backoff_s * self.backoff_factor) > self.max_backoff_s:
                     backoff_s = 1
-   
+
     async def shutdown(self, loop, signal):
         if signal:
             logging.info(f'{self.TAG}: received exit signal {signal.name}...')
@@ -102,7 +104,7 @@ class ClientManager:
 
         logging.info(f"{self.TAG}: cancelling {len(tasks)} outstanding tasks")
         await asyncio.gather(*tasks, return_exceptions=True)
-        
+
         loop.stop()
 
     async def run_client(self, host: str, port: int):
@@ -125,6 +127,7 @@ class ClientManager:
         try:
             while True:
                 msg_dict = await self.publish_queue.get()
+                msg_dict['date'] = datetime.now().isoformat()
                 payload = json.dumps(msg_dict).encode()
                 topic = msg_dict['message']['type']
                 await producer.send_and_wait(topic, payload)
@@ -155,31 +158,54 @@ class ClientManager:
     ################################
     # Callbacks for Client instances
     ################################
-    async def on_add_call(self, call_name: str, call_id: str, client_endpoint: Client):
-        if call_id not in self.calls:
-            self.calls[call_id] = Call(manager=self, call_name=call_name, call_id=call_id)
-        await self.calls[call_id].add(client_endpoint)
 
-    async def on_update_call(self, call_id: str, client_endpoint: Client):
-        pass  # TODO: don't know yet, maybe when call becomes distributed??
+    async def on_call_list_update(self, msg: dict, client_endpoint: Client):
+        updates = msg["message"]["updates"]
+        for update in updates:
+            update_type = update["updateType"]
+            call_name = update["name"]
 
-    async def on_remove_call(self, call_id: str, client_endpoint: Client):
-        if call_id not in self.calls:
+            if update_type == 'add':
+                if not (call := self.calls.get(call_name, None)):
+                    call = self.calls[call_name] = Call(manager=self, call_name=call_name)
+                await call.add(client_endpoint)
+            elif update_type == 'remove':
+                if call_name not in self.calls:
+                    logging.warning(f'{self.TAG}: received {msg} for non-tracked {call_name}')
+                    continue
+
+                call = self.calls[call_name]
+                await call.remove(client_endpoint)
+                if call.done:
+                    del self.calls[call_name]
+
+        await self.publish(msg)
+        await self.dump(msg)
+
+    async def on_call_info_update(self, msg: dict, call_name: str):
+        if not (call := self.calls.get(call_name, None)):
+            logging.warning(f'{self.TAG}: received {msg} for non-tracked {call_name}')
             return
+        msg['startDatetime'] = call.start_datetime
+        await self.publish(msg)
+        await self.dump(msg)
 
-        call = self.calls[call_id]
-        await call.remove(client_endpoint)
-        if call.done:
-            del self.calls[call_id]
+    async def on_roster_update(self, msg: dict, call_name: str):
+        if not (call := self.calls.get(call_name, None)):
+            logging.warning(f'{self.TAG}: received {msg} for non-tracked {call_name}')
+            return
+        msg['startDatetime'] = call.start_datetime
+        await self.publish(msg)
+        await self.dump(msg)
 
 
 class Call:
-    def __init__(self, manager, call_name, call_id):
+    def __init__(self, manager, call_name):
         self.manager = manager
         self.call_name = call_name
-        self.call_id = call_id
         self.handler = None
         self.clients = set()
+        self.start_datetime = datetime.now().isoformat()
 
     @property
     def handled(self):
@@ -195,21 +221,20 @@ class Call:
             self.clients.add(client)
         else:
             # No one's been listening so this client will
-            # self.clients.discard(client)
             self.handler = client
-            await client.on_connect_to(self.call_name, self.call_id)
+            await client.on_connect_to(self.call_name)
 
     async def remove(self, client):
         if client == self.handler:
             # All clients left server we've been listening to so far,
             # we need a new client to take over
             try:
+                await self.handler.on_disconnect_from(self.call_name)
                 self.handler = next(iter(self.clients))
                 self.clients.discard(self.handler)
-                await self.handler.on_connect_to(self.call_name, self.call_id)
+                await self.handler.on_connect_to(self.call_name)
             except StopIteration:
                 # No other clients
                 self.handler = None
         else:
             self.clients.remove(client)
-

--- a/bridge-connector/src/connector/client/manager.py
+++ b/bridge-connector/src/connector/client/manager.py
@@ -16,6 +16,9 @@ from ..config import Config
 
 # TODO:
 #  - do we even need callId at all?
+#  - if Kafka producer slows down for whatever reason queues will overflow
+#    - we can't drop callListUpdate events - required to know conversation state in later processing stages
+#    - but we could theoretically drop roster and callInfo updates
 #  - exception handling
 #    - failure to fetch token
 #    - HTTP 401 (?) error - refresh token?

--- a/bridge-connector/src/connector/client/manager.py
+++ b/bridge-connector/src/connector/client/manager.py
@@ -222,10 +222,12 @@ class Call:
         if self.handled:
             # Some client is listening already
             self.clients.add(client)
+            logging.info(f'{self.manager.TAG}: {self.call_name} running on {len(self.clients) + 1} servers')
         else:
             # No one's been listening so this client will
             self.handler = client
             await client.on_connect_to(self.call_name)
+            logging.info(f'{self.manager.TAG}: {self.call_name} running on 1 server')
 
     async def remove(self, client):
         if client == self.handler:
@@ -241,3 +243,11 @@ class Call:
                 self.handler = None
         else:
             self.clients.remove(client)
+
+        if self.handler:
+            msg = f'{self.manager.TAG}: {self.call_name} running on {len(self.clients) + 1} server'
+            if self.clients:
+                msg += 's'
+            logging.info(msg)
+        else:
+            logging.info(f'{self.manager.TAG}: {self.call_name} finished on all servers')

--- a/bridge-connector/test/server.py
+++ b/bridge-connector/test/server.py
@@ -15,6 +15,7 @@ from typing import Dict, List
 #  - acknowledgements and subscriptionUpdates are ignored and not sent at all
 #  - if subscribed to "calls", clients get all "calls" events from log in order
 
+
 @dataclass
 class DetailSubscription:
     index: int


### PR DESCRIPTION
Also included a fix - roster and callInfo messages in a conversation now come from single bridge only - others provide redundant info (according to docs). Should reduce number in duplicates in DB.